### PR TITLE
Get gifs running.

### DIFF
--- a/src/com/example/testGlide/URLImageParser.java
+++ b/src/com/example/testGlide/URLImageParser.java
@@ -1,10 +1,6 @@
 package com.example.testGlide;
 
 import android.content.Context;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.ColorFilter;
-import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.text.Html;
 import android.util.DisplayMetrics;
@@ -29,7 +25,7 @@ public class URLImageParser implements Html.ImageGetter {
     }
 
     @Override
-    public Drawable getDrawable(String url) {
+    public Drawable getDrawable(final String url) {
         final UrlDrawable urlDrawable = new UrlDrawable();
         final String source = url;
 
@@ -38,8 +34,27 @@ public class URLImageParser implements Html.ImageGetter {
         ((WindowManager) container.getContext().getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getMetrics(metrics);
         final float dpi = (int) metrics.density;
 
-        Glide.with(container.getContext()).load(source).diskCacheStrategy(DiskCacheStrategy.ALL).
-                listener(new RequestListener<String, GlideDrawable>() {
+        Drawable.Callback callback = new Drawable.Callback() {
+
+            @Override
+            public void invalidateDrawable(Drawable drawable) {
+                container.invalidate();
+            }
+
+            @Override
+            public void scheduleDrawable(Drawable drawable, Runnable runnable, long l) {
+            }
+
+            @Override
+            public void unscheduleDrawable(Drawable drawable, Runnable runnable) {
+
+            }
+        };
+        container.setTag(R.id.callback_id, callback);
+
+        Glide.with(container.getContext()).load(source)
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .listener(new RequestListener<String, GlideDrawable>() {
                     @Override
                     public boolean onException(Exception e, String s, Target<GlideDrawable> glideDrawableTarget, boolean b) {
                         debug("Error in Glide listener");
@@ -62,26 +77,10 @@ public class URLImageParser implements Html.ImageGetter {
                         d.setBounds(0, 0, width, height);
                         d.setVisible(true, true);
 
-                        d.setCallback(new Drawable.Callback() {
-                            @Override
-                            public void invalidateDrawable(Drawable who) {
-
-                            }
-
-                            @Override
-                            public void scheduleDrawable(Drawable who, Runnable what, long when) {
-
-                            }
-
-                            @Override
-                            public void unscheduleDrawable(Drawable who, Runnable what) {
-
-                            }
-                        });
-
                         urlDrawable.setBounds(0, 0, width, height);
-                        urlDrawable.drawable = d;
-                        debug("Lisnt1er ended " + width + ", " + height + ", source: " + source + ", animated? " + d.isAnimated() + ", " + d.getClass().getSimpleName());
+                        urlDrawable.setDrawable(d);
+                        urlDrawable.setCallback((Drawable.Callback) container.getTag(R.id.callback_id));
+                        debug("Lisnter ended " + width + ", " + height + ", source: " + source + ", animated? " + d.isAnimated() + ", " + d.getClass().getSimpleName());
 
                         if (d instanceof GifDrawable) {
                             debug("Gif drawable ! animated? " + d.isAnimated() + ", " + (d.getCallback() == null));

--- a/src/com/example/testGlide/UrlDrawable.java
+++ b/src/com/example/testGlide/UrlDrawable.java
@@ -1,20 +1,15 @@
 package com.example.testGlide;
 
-import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
-import android.graphics.drawable.LevelListDrawable;
-import android.util.Log;
-import android.view.View;
-import android.widget.TextView;
 import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 
 
-public class UrlDrawable extends Drawable {
-    public GlideDrawable drawable;
+public class UrlDrawable extends Drawable implements Drawable.Callback {
+    private GlideDrawable drawable;
 
     public UrlDrawable() {
         super();
@@ -25,6 +20,15 @@ public class UrlDrawable extends Drawable {
         if (drawable != null) {
             drawable.setAlpha(alpha);
         }
+    }
+
+    public void setDrawable(GlideDrawable drawable) {
+        if (this.drawable != null) {
+            this.drawable.setCallback(null);
+        }
+        drawable.setCallback(this);
+        this.drawable = drawable;
+
     }
 
     @Override
@@ -42,6 +46,7 @@ public class UrlDrawable extends Drawable {
         return 0;
     }
 
+
     @Override
     public void draw(Canvas canvas) {
 // override the draw to facilitate refresh function later
@@ -55,5 +60,29 @@ public class UrlDrawable extends Drawable {
                 drawable.start();
             }
         }
+    }
+
+    @Override
+    public void invalidateDrawable(Drawable drawable) {
+        if (getCallback() == null) {
+            return;
+        }
+        getCallback().invalidateDrawable(drawable);
+    }
+
+    @Override
+    public void scheduleDrawable(Drawable drawable, Runnable runnable, long l) {
+        if (getCallback() == null) {
+            return;
+        }
+        getCallback().scheduleDrawable(drawable, runnable, l);
+    }
+
+    @Override
+    public void unscheduleDrawable(Drawable drawable, Runnable runnable) {
+        if (getCallback() == null) {
+            return;
+        }
+        getCallback().unscheduleDrawable(drawable, runnable);
     }
 }

--- a/src/main/res/values/ids.xml
+++ b/src/main/res/values/ids.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>


### PR DESCRIPTION
A couple of issues here.
1. Setting an anonymous inner class as the callback isn't sufficient because Drawables hold on to their callbacks using WeakReferences. Since you weren't referencing the callback, it was quickly cleared, leaving your drawables without a callback.
2. Even if you get around #1 by setting your TextView as the callback, that still doesn't work because the TextView ignores calls to invalidate for Drawables that aren't it's left, right, top, or bottom drawables. You can see this logic in `verifyDrawable` on line 4776: https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/widget/TextView.java. 

To actually get gifs to play, I used a tag to hold on the callback so it was referenced strongly, and then created a custom callback that invalidates the view without verifying the drawable first which gets things playing.

However, the reason why this is so complicated is that you're trying to display images in `TextView`. I definitely do not recommend doing that, and things will definitely be broken if you try to make this work. Instead try using an `ImageView` or if you need text and an image, wrap a `TextView` and an `ImageView` in a `ViewGroup`
